### PR TITLE
Add Dockerfile and .dockerignore for the noteapp

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,16 @@
+# Git
+.git
+.gitignore
+
+# Python
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+pip-cache/
+venv/
+*.env
+
+# Django
+db.sqlite3
+*.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+# Use an official Python 3.9 image as the base
+FROM python:3.9
+
+# Set up a working directory /app
+WORKDIR /app
+
+# Copy requirements.txt to /app/requirements.txt
+COPY noteapp/requirements.txt /app/requirements.txt
+
+# Install dependencies using pip install -r requirements.txt
+RUN pip install -r requirements.txt
+
+# Copy the noteapp directory to /app/noteapp
+COPY noteapp /app/noteapp
+
+# Expose port 8000
+EXPOSE 8000
+
+# Set the default command to python noteapp/manage.py runserver 0.0.0.0:8000
+CMD ["python", "noteapp/manage.py", "runserver", "0.0.0.0:8000"]

--- a/noteapp/README.md
+++ b/noteapp/README.md
@@ -30,6 +30,26 @@ A simple note-taking application built with Django and Tailwind CSS. Users can c
 - Use the "New Note" button to create a new note
 - Edit or delete notes from their detail page
 
+## Running with Docker
+
+To build and run this application using Docker, follow these steps:
+
+1.  **Build the Docker image:**
+    ```bash
+    docker build -t noteapp .
+    ```
+
+2.  **Run the Docker container:**
+    ```bash
+    docker run -p 8000:8000 noteapp
+    ```
+    This will start the Django development server inside the container, accessible at `http://localhost:8000` on your host machine.
+
+    To run the container in detached mode (in the background), use the `-d` flag:
+    ```bash
+    docker run -d -p 8000:8000 noteapp
+    ```
+
 ## Technologies
 
 - Django


### PR DESCRIPTION
This commit introduces a Dockerfile to containerize the Django note-taking application.

Key changes:
- Added a `Dockerfile` at the project root:
    - Uses `python:3.9` as the base image.
    - Sets up a working directory, copies requirements, and installs them.
    - Copies the `noteapp` application code.
    - Exposes port 8000.
    - Runs the Django development server on container startup.
- Added a `.dockerignore` file to exclude unnecessary files and directories (e.g., `.git`, `__pycache__`, `db.sqlite3`) from the Docker build context, leading to faster and smaller image builds.
- Updated `noteapp/README.md` with a new "Running with Docker" section, providing instructions on how to build and run the application using Docker.